### PR TITLE
remove bottom padding on carousel

### DIFF
--- a/src/@carbon-info/views/Ecosystem/components/AppsCarousel.tsx
+++ b/src/@carbon-info/views/Ecosystem/components/AppsCarousel.tsx
@@ -62,7 +62,6 @@ const AppsCarousel: React.FC<Props> = (props: Props) => {
 const useStyles = makeStyles((theme: Theme) => ({
   carouselContainer: {
     display: "flex",
-    paddingBottom: "5rem",
     "& > ul": {
       alignItems: "flex-end",
       "& > li": {


### PR DESCRIPTION
[Notion Card
](https://www.notion.so/switcheo/Add-Carbon-Core-Carbon-EVM-on-Carbon-landing-page-eebdd574966e484dac073b2b3b8293c2?pvs=4) - follow up PR from QA comments

very small follow up PR to remove padding :)

prev:
<img width="356" alt="image" src="https://github.com/Switcheo/carbon-website/assets/109417597/4c81ab45-1b22-4ebf-82a4-0e5e74029e94">


fix: (clemence says it looks ok alr!)
<img width="356" alt="image" src="https://github.com/Switcheo/carbon-website/assets/109417597/c4468e69-5bda-4b56-ba42-ccdd1f9d7301">

